### PR TITLE
Update configure.defaults to support a Linux aarch64 gfortran option

### DIFF
--- a/arch/configure.defaults
+++ b/arch/configure.defaults
@@ -189,7 +189,7 @@ CPPFLAGS            = -D_UNDERSCORE -DBYTESWAP -DLINUX -DIO_NETCDF -DBIT32 -DNO_
 RANLIB              = ranlib
 
 ########################################################################################################################
-#ARCH    Linux x86_64, gfortran   # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
+#ARCH    Linux x86_64 aarch64, gfortran   # serial serial_NO_GRIB2 dmpar dmpar_NO_GRIB2
 #
 COMPRESSION_LIBS    = CONFIGURE_COMP_L
 COMPRESSION_INC     = CONFIGURE_COMP_I


### PR DESCRIPTION
This one line change extends the  `Linux x86_64, gfortran` stanza to support `aarch64` (ARM processors) as well by simply changing the definition to `Linux x86_64 aarch64, gfortran` 

Since there are no required differences when using `gfortran` on these two architectures this seemed like the best approach.

Let me know if you would instead prefer a new stanza, with identical content.